### PR TITLE
Remove dart:io upper-case constants.

### DIFF
--- a/lib/http_io.dart
+++ b/lib/http_io.dart
@@ -11,7 +11,7 @@ import 'dart:convert';
 import 'dart:io'
     show
         BytesBuilder,
-        GZIP,
+        gzip,
         HandshakeException,
         InternetAddress,
         IOSink,
@@ -64,7 +64,7 @@ part 'src/http_overrides.dart';
  *
  *     main() {
  *       HttpServer
- *           .bind(InternetAddress.ANY_IP_V6, 80)
+ *           .bind(InternetAddress.anyIpV6, 80)
  *           .then((server) {
  *             server.listen((HttpRequest request) {
  *               request.response.write('Hello, world!');
@@ -105,7 +105,7 @@ part 'src/http_overrides.dart';
  *       context.usePrivateKey(key, password: 'dartdart');
  *
  *       HttpServer
- *           .bindSecure(InternetAddress.ANY_IP_V6,
+ *           .bindSecure(InternetAddress.anyIpV6,
  *                       443,
  *                       context)
  *           .then((server) {
@@ -127,7 +127,7 @@ part 'src/http_overrides.dart';
  *     import 'dart:io';
  *
  *     main() {
- *       ServerSocket.bind(InternetAddress.ANY_IP_V6, 80)
+ *       ServerSocket.bind(InternetAddress.anyIpV6, 80)
  *         .then((serverSocket) {
  *           HttpServer httpserver = new HttpServer.listenOn(serverSocket);
  *           serverSocket.listen((Socket socket) {
@@ -209,17 +209,17 @@ abstract class HttpServer implements Stream<HttpRequest> {
    * perform a [InternetAddress.lookup] and use the first value in the
    * list. To listen on the loopback adapter, which will allow only
    * incoming connections from the local host, use the value
-   * [InternetAddress.LOOPBACK_IP_V4] or
-   * [InternetAddress.LOOPBACK_IP_V6]. To allow for incoming
+   * [InternetAddress.loopbackIpV4] or
+   * [InternetAddress.loopbackIpV6]. To allow for incoming
    * connection from the network use either one of the values
-   * [InternetAddress.ANY_IP_V4] or [InternetAddress.ANY_IP_V6] to
+   * [InternetAddress.anyIpV4] or [InternetAddress.anyIpV6] to
    * bind to all interfaces or the IP address of a specific interface.
    *
    * If an IP version 6 (IPv6) address is used, both IP version 6
    * (IPv6) and version 4 (IPv4) connections will be accepted. To
    * restrict this to version 6 (IPv6) only, use [v6Only] to set
    * version 6 only. However, if the address is
-   * [InternetAddress.LOOPBACK_IP_V6], only IP version 6 (IPv6) connections
+   * [InternetAddress.loopbackIpV6], only IP version 6 (IPv6) connections
    * will be accepted.
    *
    * If [port] has the value [:0:] an ephemeral port will be chosen by
@@ -248,10 +248,10 @@ abstract class HttpServer implements Stream<HttpRequest> {
    * perform a [InternetAddress.lookup] and use the first value in the
    * list. To listen on the loopback adapter, which will allow only
    * incoming connections from the local host, use the value
-   * [InternetAddress.LOOPBACK_IP_V4] or
-   * [InternetAddress.LOOPBACK_IP_V6]. To allow for incoming
+   * [InternetAddress.loopbackIpV4] or
+   * [InternetAddress.loopbackIpV6]. To allow for incoming
    * connection from the network use either one of the values
-   * [InternetAddress.ANY_IP_V4] or [InternetAddress.ANY_IP_V6] to
+   * [InternetAddress.anyIpV4] or [InternetAddress.anyIpV6] to
    * bind to all interfaces or the IP address of a specific interface.
    *
    * If an IP version 6 (IPv6) address is used, both IP version 6
@@ -884,7 +884,7 @@ abstract class Cookie {
  * for HTTP requests. When the server receives a request,
  * it uses the HttpRequest object's `method` property to dispatch requests.
  *
- *     final HOST = InternetAddress.LOOPBACK_IP_V4;
+ *     final HOST = InternetAddress.loopbackIpV4;
  *     final PORT = 80;
  *
  *     HttpServer.bind(HOST, PORT).then((_server) {

--- a/lib/http_io.dart
+++ b/lib/http_io.dart
@@ -64,7 +64,7 @@ part 'src/http_overrides.dart';
  *
  *     main() {
  *       HttpServer
- *           .bind(InternetAddress.anyIpV6, 80)
+ *           .bind(InternetAddress.anyIPv6, 80)
  *           .then((server) {
  *             server.listen((HttpRequest request) {
  *               request.response.write('Hello, world!');
@@ -105,7 +105,7 @@ part 'src/http_overrides.dart';
  *       context.usePrivateKey(key, password: 'dartdart');
  *
  *       HttpServer
- *           .bindSecure(InternetAddress.anyIpV6,
+ *           .bindSecure(InternetAddress.anyIPv6,
  *                       443,
  *                       context)
  *           .then((server) {
@@ -127,7 +127,7 @@ part 'src/http_overrides.dart';
  *     import 'dart:io';
  *
  *     main() {
- *       ServerSocket.bind(InternetAddress.anyIpV6, 80)
+ *       ServerSocket.bind(InternetAddress.anyIPv6, 80)
  *         .then((serverSocket) {
  *           HttpServer httpserver = new HttpServer.listenOn(serverSocket);
  *           serverSocket.listen((Socket socket) {
@@ -209,17 +209,17 @@ abstract class HttpServer implements Stream<HttpRequest> {
    * perform a [InternetAddress.lookup] and use the first value in the
    * list. To listen on the loopback adapter, which will allow only
    * incoming connections from the local host, use the value
-   * [InternetAddress.loopbackIpV4] or
-   * [InternetAddress.loopbackIpV6]. To allow for incoming
+   * [InternetAddress.loopbackIPv4] or
+   * [InternetAddress.loopbackIPv6]. To allow for incoming
    * connection from the network use either one of the values
-   * [InternetAddress.anyIpV4] or [InternetAddress.anyIpV6] to
+   * [InternetAddress.anyIPv4] or [InternetAddress.anyIPv6] to
    * bind to all interfaces or the IP address of a specific interface.
    *
    * If an IP version 6 (IPv6) address is used, both IP version 6
    * (IPv6) and version 4 (IPv4) connections will be accepted. To
    * restrict this to version 6 (IPv6) only, use [v6Only] to set
    * version 6 only. However, if the address is
-   * [InternetAddress.loopbackIpV6], only IP version 6 (IPv6) connections
+   * [InternetAddress.loopbackIPv6], only IP version 6 (IPv6) connections
    * will be accepted.
    *
    * If [port] has the value [:0:] an ephemeral port will be chosen by
@@ -248,10 +248,10 @@ abstract class HttpServer implements Stream<HttpRequest> {
    * perform a [InternetAddress.lookup] and use the first value in the
    * list. To listen on the loopback adapter, which will allow only
    * incoming connections from the local host, use the value
-   * [InternetAddress.loopbackIpV4] or
-   * [InternetAddress.loopbackIpV6]. To allow for incoming
+   * [InternetAddress.loopbackIPv4] or
+   * [InternetAddress.loopbackIPv6]. To allow for incoming
    * connection from the network use either one of the values
-   * [InternetAddress.anyIpV4] or [InternetAddress.anyIpV6] to
+   * [InternetAddress.anyIPv4] or [InternetAddress.anyIPv6] to
    * bind to all interfaces or the IP address of a specific interface.
    *
    * If an IP version 6 (IPv6) address is used, both IP version 6
@@ -884,7 +884,7 @@ abstract class Cookie {
  * for HTTP requests. When the server receives a request,
  * it uses the HttpRequest object's `method` property to dispatch requests.
  *
- *     final HOST = InternetAddress.loopbackIpV4;
+ *     final HOST = InternetAddress.loopbackIPv4;
  *     final PORT = 80;
  *
  *     HttpServer.bind(HOST, PORT).then((_server) {

--- a/lib/src/http_impl.dart
+++ b/lib/src/http_impl.dart
@@ -308,7 +308,7 @@ class _HttpClientResponse extends _HttpInboundMessage
     Stream<List<int>> stream = _incoming;
     if (_httpClient.autoUncompress &&
         headers.value(HttpHeaders.CONTENT_ENCODING) == "gzip") {
-      stream = stream.transform(GZIP.decoder);
+      stream = stream.transform(gzip.decoder);
     }
     return stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
@@ -1853,7 +1853,7 @@ class _ConnectionTarget {
     _connecting++;
     return socketFuture.then((socket) {
       _connecting--;
-      socket.setOption(SocketOption.TCP_NODELAY, true);
+      socket.setOption(SocketOption.tcpNodelay, true);
       var connection =
           new _HttpClientConnection(key, socket, client, false, context);
       if (isSecure && !proxy.isDirect) {
@@ -2439,7 +2439,7 @@ class _HttpServer extends Stream<HttpRequest> implements HttpServer {
   StreamSubscription<HttpRequest> listen(void onData(HttpRequest event),
       {Function onError, void onDone(), bool cancelOnError}) {
     _serverSocket.listen((Socket socket) {
-      socket.setOption(SocketOption.TCP_NODELAY, true);
+      socket.setOption(SocketOption.tcpNodelay, true);
       // Accept the client connection.
       _HttpConnection connection = new _HttpConnection(socket, this);
       _idleConnections.add(connection);

--- a/lib/src/http_impl.dart
+++ b/lib/src/http_impl.dart
@@ -1853,7 +1853,7 @@ class _ConnectionTarget {
     _connecting++;
     return socketFuture.then((socket) {
       _connecting--;
-      socket.setOption(SocketOption.tcpNodelay, true);
+      socket.setOption(SocketOption.tcpNoDelay, true);
       var connection =
           new _HttpClientConnection(key, socket, client, false, context);
       if (isSecure && !proxy.isDirect) {
@@ -2439,7 +2439,7 @@ class _HttpServer extends Stream<HttpRequest> implements HttpServer {
   StreamSubscription<HttpRequest> listen(void onData(HttpRequest event),
       {Function onError, void onDone(), bool cancelOnError}) {
     _serverSocket.listen((Socket socket) {
-      socket.setOption(SocketOption.tcpNodelay, true);
+      socket.setOption(SocketOption.tcpNoDelay, true);
       // Accept the client connection.
       _HttpConnection connection = new _HttpConnection(socket, this);
       _idleConnections.add(connection);

--- a/test/http_compression_test.dart
+++ b/test/http_compression_test.dart
@@ -32,7 +32,7 @@ Future<Null> testWithData(List<int> data, {bool clientAutoUncompress: true}) {
         if (clientAutoUncompress) {
           expect(data, equals(list));
         } else {
-          expect(data, equals(GZIP.decode(list)));
+          expect(data, equals(gzip.decode(list)));
         }
         server.close();
         client.close();

--- a/test/http_cross_process_test.dart
+++ b/test/http_cross_process_test.dart
@@ -31,7 +31,7 @@ void runTest() {
 }
 
 Future<HttpServer> makeServer() {
-  return HttpServer.bind(InternetAddress.loopbackIpV4, 0).then((server) {
+  return HttpServer.bind(InternetAddress.loopbackIPv4, 0).then((server) {
     server.listen((request) {
       request.pipe(request.response);
     });

--- a/test/http_cross_process_test.dart
+++ b/test/http_cross_process_test.dart
@@ -31,7 +31,7 @@ void runTest() {
 }
 
 Future<HttpServer> makeServer() {
-  return HttpServer.bind(InternetAddress.LOOPBACK_IP_V4, 0).then((server) {
+  return HttpServer.bind(InternetAddress.loopbackIpV4, 0).then((server) {
     server.listen((request) {
       request.pipe(request.response);
     });


### PR DESCRIPTION
More constants. 

No update to pubspec.yaml since this package has never been released anyway (right?)