### PR TITLE
List<int> to Uint8List conversion

### DIFF
--- a/lib/src/http_impl.dart
+++ b/lib/src/http_impl.dart
@@ -61,14 +61,14 @@ class _CopyingBytesBuilder implements BytesBuilder {
     _buffer = newBuffer;
   }
 
-  List<int> takeBytes() {
+  Uint8List takeBytes() {
     if (_length == 0) return _emptyList;
     var buffer = new Uint8List.view(_buffer.buffer, 0, _length);
     clear();
     return buffer;
   }
 
-  List<int> toBytes() {
+  Uint8List toBytes() {
     if (_length == 0) return _emptyList;
     return new Uint8List.fromList(
         new Uint8List.view(_buffer.buffer, 0, _length));


### PR DESCRIPTION
This updates `_CopyingBytesBuilder` such that `takeBytes()` and `toBytes()`
both declare a return type of `Uint8List` rather than `List<int>`.

This is in preparation for an SDK update whereby the API of
`BytesBuilder` will receive the same update.

https://github.com/dart-lang/sdk/issues/36900