### PR TITLE
Cast stream to List<int>

### DIFF
--- a/test/http_server_early_client_close2_test.dart
+++ b/test/http_server_early_client_close2_test.dart
@@ -19,6 +19,7 @@ Future<Null> httpServerEarlyClientClose2() {
       }
       new File(name)
           .openRead()
+          .cast<List<int>>()
           .pipe(request.response)
           .catchError((e) {/* ignore */});
     });

--- a/test/http_server_early_client_close_test.dart
+++ b/test/http_server_early_client_close_test.dart
@@ -104,6 +104,7 @@ Future<Null> testEarlyClose2() {
       }
       new File(name)
           .openRead()
+          .cast<List<int>>()
           .pipe(request.response)
           .catchError((e) {/* ignore */});
     });

--- a/test/http_server_response_test.dart
+++ b/test/http_server_response_test.dart
@@ -148,6 +148,7 @@ Future<List> testResponseAddStream() {
   testServerRequest((server, request) {
     new File("__nonexistent_file_")
         .openRead()
+        .cast<List<int>>()
         .pipe(request.response)
         .catchError((e) {
       server.close();
@@ -162,7 +163,9 @@ Future<Null> testResponseAddStreamClosed() {
   final completer = new Completer<Null>();
   File file = scriptSource;
   testServerRequest((server, request) {
-    request.response.addStream(file.openRead()).then((response) {
+    request.response
+        .addStream(file.openRead().cast<List<int>>())
+        .then((response) {
       response.close();
       response.done.then((_) => server.close());
     });


### PR DESCRIPTION
This is in preparation for HttpClientResponse implementing
Stream<Uint8List> and File.openRead() returning a Stream<Uint8List>.
It is a forwards-compatible change that should be a no-op for
existing usages.

dart-lang/sdk#36900