### PR TITLE
Cast File.openRead() stream to List<int>

### DIFF
--- a/test/http_server_response_test.dart
+++ b/test/http_server_response_test.dart
@@ -67,6 +67,7 @@ Future<List> testResponseDone() {
   testServerRequest((server, request) {
     new File("__nonexistent_file_")
         .openRead()
+        .cast<List<int>>()
         .pipe(request.response)
         .catchError((e) {
       server.close();


### PR DESCRIPTION
This is in preparation for File.openRead() returning
a `Stream<Uint8List>` rather than `Stream<List<int>>`.
This is a forwards-compatible change that should be
a no-op for existing usages.

dart-lang/sdk#36900