### PR TITLE
Socket implements Stream<Uint8List>

### DIFF
--- a/lib/src/http_impl.dart
+++ b/lib/src/http_impl.dart
@@ -308,7 +308,7 @@ class _HttpClientResponse extends _HttpInboundMessage
     Stream<List<int>> stream = _incoming;
     if (_httpClient.autoUncompress &&
         headers.value(HttpHeaders.CONTENT_ENCODING) == "gzip") {
-      stream = stream.transform(gzip.decoder);
+      stream = gzip.decoder.bind(stream);
     }
     return stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
@@ -2696,13 +2696,13 @@ class _HttpConnectionInfo implements HttpConnectionInfo {
   }
 }
 
-class _DetachedSocket extends Stream<List<int>> implements Socket {
-  final Stream<List<int>> _incoming;
+class _DetachedSocket extends Stream<Uint8List> implements Socket {
+  final Stream<Uint8List> _incoming;
   final Socket _socket;
 
   _DetachedSocket(this._socket, this._incoming);
 
-  StreamSubscription<List<int>> listen(void onData(List<int> event),
+  StreamSubscription<Uint8List> listen(void onData(Uint8List event),
       {Function onError, void onDone(), bool cancelOnError}) {
     return _incoming.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
@@ -2738,7 +2738,7 @@ class _DetachedSocket extends Stream<List<int>> implements Socket {
       _socket.addError(error, stackTrace);
 
   Future addStream(Stream<List<int>> stream) {
-    return _socket.addStream(stream);
+    return _socket.addStream(stream.cast<List<int>>());
   }
 
   void destroy() {

--- a/lib/src/http_parser.dart
+++ b/lib/src/http_parser.dart
@@ -69,9 +69,9 @@ class _MessageType {
  * _HttpDetachedStreamSubscription is resumed, it'll deliver the data before
  * resuming the underlaying subscription.
  */
-class _HttpDetachedStreamSubscription implements StreamSubscription<List<int>> {
-  StreamSubscription<List<int>> _subscription;
-  List<int> _injectData;
+class _HttpDetachedStreamSubscription implements StreamSubscription<Uint8List> {
+  StreamSubscription<Uint8List> _subscription;
+  Uint8List _injectData;
   bool _isCanceled = false;
   int _pauseCount = 1;
   Function _userOnData;
@@ -91,7 +91,7 @@ class _HttpDetachedStreamSubscription implements StreamSubscription<List<int>> {
     return _subscription.cancel();
   }
 
-  void onData(void handleData(List<int> data)) {
+  void onData(void handleData(Uint8List data)) {
     _userOnData = handleData;
     _subscription.onData(handleData);
   }
@@ -143,13 +143,13 @@ class _HttpDetachedStreamSubscription implements StreamSubscription<List<int>> {
   }
 }
 
-class HttpDetachedIncoming extends Stream<List<int>> {
-  final StreamSubscription<List<int>> subscription;
-  final List<int> bufferedData;
+class HttpDetachedIncoming extends Stream<Uint8List> {
+  final StreamSubscription<Uint8List> subscription;
+  final Uint8List bufferedData;
 
   HttpDetachedIncoming(this.subscription, this.bufferedData);
 
-  StreamSubscription<List<int>> listen(void onData(List<int> event),
+  StreamSubscription<Uint8List> listen(void onData(Uint8List event),
       {Function onError, void onDone(), bool cancelOnError}) {
     if (subscription != null) {
       subscription
@@ -164,7 +164,7 @@ class HttpDetachedIncoming extends Stream<List<int>> {
         ..resume();
     } else {
       // TODO(26379): add test for this branch.
-      return new Stream<List<int>>.fromIterable([bufferedData]).listen(onData,
+      return new Stream<Uint8List>.fromIterable([bufferedData]).listen(onData,
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
     }
   }
@@ -222,11 +222,11 @@ class HttpParser extends Stream<HttpIncoming> {
 
   // The current incoming connection.
   HttpIncoming _incoming;
-  StreamSubscription<List<int>> _socketSubscription;
+  StreamSubscription<Uint8List> _socketSubscription;
   bool _paused = true;
   bool _bodyPaused = false;
   StreamController<HttpIncoming> _controller;
-  StreamController<List<int>> _bodyController;
+  StreamController<Uint8List> _bodyController;
 
   factory HttpParser.requestParser() {
     return new HttpParser._(true);
@@ -264,7 +264,7 @@ class HttpParser extends Stream<HttpIncoming> {
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
-  void listenToStream(Stream<List<int>> stream) {
+  void listenToStream(Stream<Uint8List> stream) {
     // Listen to the stream and handle data accordingly. When a
     // _HttpIncoming is created, _dataPause, _dataResume, _dataDone is
     // given to provide a way of controlling the parser.
@@ -725,7 +725,7 @@ class HttpParser extends Stream<HttpIncoming> {
           // Always present the data as a view. This way we can handle all
           // cases like this, and the user will not experience different data
           // typed (which could lead to polymorphic user code).
-          List<int> data = new Uint8List.view(
+          Uint8List data = new Uint8List.view(
               _buffer.buffer, _buffer.offsetInBytes + _index, dataAvailable);
           _bodyController.add(data);
           if (_remainingContent != -1) {
@@ -765,7 +765,7 @@ class HttpParser extends Stream<HttpIncoming> {
     }
   }
 
-  void _onData(List<int> buffer) {
+  void _onData(Uint8List buffer) {
     _socketSubscription.pause();
     assert(_buffer == null);
     _buffer = buffer;
@@ -851,7 +851,7 @@ class HttpParser extends Stream<HttpIncoming> {
     return new HttpDetachedIncoming(_socketSubscription, readUnparsedData());
   }
 
-  List<int> readUnparsedData() {
+  Uint8List readUnparsedData() {
     if (_buffer == null) return null;
     if (_index == _buffer.length) return null;
     var result = _buffer.sublist(_index);
@@ -946,7 +946,7 @@ class HttpParser extends Stream<HttpIncoming> {
     assert(_bodyController == null);
     assert(!_bodyPaused);
     HttpIncoming incoming;
-    _bodyController = new StreamController<List<int>>(
+    _bodyController = new StreamController<Uint8List>(
         sync: true,
         onListen: () {
           if (incoming != _incoming) return;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/dart-lang/http_io
 description: HTTP Client and Server APIs.
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.5.0-dev.0.0 <3.0.0"
 
 dev_dependencies:
   convert: ^2.0.1

--- a/test/http_detach_socket_test.dart
+++ b/test/http_detach_socket_test.dart
@@ -158,7 +158,7 @@ Future<Null> testUpgradedConnection() {
       request.response.headers.set('connection', 'upgrade');
       if (request.headers.value('upgrade') == 'mine') {
         request.response.detachSocket().then((socket) {
-          socket.pipe(socket).then((_) {});
+          socket.cast<List<int>>().pipe(socket).then((_) {});
         });
       } else {
         request.response.close();

--- a/test/http_parser_test.dart
+++ b/test/http_parser_test.dart
@@ -31,7 +31,7 @@ class HttpParserTest {
       int unparsedLength: 0,
       bool connectionClose: false,
       String expectedVersion: "1.1"}) {
-    StreamController<List<int>> controller;
+    StreamController<Uint8List> controller;
     void reset() {
       HttpParser httpParser = new HttpParser.requestParser();
       controller = new StreamController(sync: true);
@@ -101,7 +101,7 @@ class HttpParserTest {
       upgraded = false;
     }
 
-    void testWrite(List<int> requestData, [int chunkSize = -1]) {
+    void testWrite(Uint8List requestData, [int chunkSize = -1]) {
       if (chunkSize == -1) chunkSize = requestData.length;
       reset();
       for (int pos = 0; pos < requestData.length; pos += chunkSize) {
@@ -113,7 +113,7 @@ class HttpParserTest {
 
     // Test parsing the request three times delivering the data in
     // different chunks.
-    List<int> requestData = new Uint8List.fromList(request.codeUnits);
+    Uint8List requestData = new Uint8List.fromList(request.codeUnits);
     testWrite(requestData);
     testWrite(requestData, 10);
     testWrite(requestData, 1);
@@ -153,7 +153,7 @@ class HttpParserTest {
   static void _testParseInvalidRequest(String request) {
     HttpParser httpParser;
     bool errorCalled;
-    StreamController<List<int>> controller;
+    StreamController<Uint8List> controller;
 
     void reset() {
       httpParser = new HttpParser.requestParser();
@@ -173,7 +173,7 @@ class HttpParserTest {
       errorCalled = false;
     }
 
-    void testWrite(List<int> requestData, [int chunkSize = -1]) {
+    void testWrite(Uint8List requestData, [int chunkSize = -1]) {
       if (chunkSize == -1) chunkSize = requestData.length;
       reset();
       for (int pos = 0;
@@ -187,7 +187,7 @@ class HttpParserTest {
 
     // Test parsing the request three times delivering the data in
     // different chunks.
-    List<int> requestData = new Uint8List.fromList(request.codeUnits);
+    Uint8List requestData = new Uint8List.fromList(request.codeUnits);
     testWrite(requestData);
     testWrite(requestData, 10);
     testWrite(requestData, 1);
@@ -205,7 +205,7 @@ class HttpParserTest {
       bool upgrade: false,
       int unparsedLength: 0,
       String expectedVersion: "1.1"}) {
-    StreamController<List<int>> controller;
+    StreamController<Uint8List> controller;
 
     void reset() {
       HttpParser httpParser;
@@ -275,7 +275,7 @@ class HttpParserTest {
       bytesReceived = 0;
     }
 
-    void testWrite(List<int> requestData, [int chunkSize = -1]) {
+    void testWrite(Uint8List requestData, [int chunkSize = -1]) {
       if (chunkSize == -1) chunkSize = requestData.length;
       reset();
       for (int pos = 0; pos < requestData.length; pos += chunkSize) {
@@ -287,16 +287,16 @@ class HttpParserTest {
 
     // Test parsing the request three times delivering the data in
     // different chunks.
-    List<int> responseData = new Uint8List.fromList(response.codeUnits);
+    Uint8List responseData = new Uint8List.fromList(response.codeUnits);
     testWrite(responseData);
     testWrite(responseData, 10);
     testWrite(responseData, 1);
   }
 
   static void _testParseInvalidResponse(String response, [bool close = false]) {
-    void testWrite(List<int> requestData, [int chunkSize = -1]) {
+    void testWrite(Uint8List requestData, [int chunkSize = -1]) {
       HttpParser httpParser = new HttpParser.responseParser();
-      StreamController<List<int>> controller = new StreamController(sync: true);
+      StreamController<Uint8List> controller = new StreamController(sync: true);
       bool errorCalled = false;
 
       if (chunkSize == -1) chunkSize = requestData.length;
@@ -330,7 +330,7 @@ class HttpParserTest {
 
     // Test parsing the request three times delivering the data in
     // different chunks.
-    List<int> responseData = new Uint8List.fromList(response.codeUnits);
+    Uint8List responseData = new Uint8List.fromList(response.codeUnits);
     testWrite(responseData);
     testWrite(responseData, 10);
     testWrite(responseData, 1);

--- a/test/http_proxy_advanced_test.dart
+++ b/test/http_proxy_advanced_test.dart
@@ -237,8 +237,8 @@ class ProxyServer {
           Socket.connect(tmp[0], int.parse(tmp[1])).then((socket) {
             request.response.reasonPhrase = "Connection established";
             request.response.detachSocket().then((detached) {
-              socket.pipe(detached);
-              detached.pipe(socket);
+              socket.cast<List<int>>().pipe(detached);
+              detached.cast<List<int>>().pipe(socket);
             });
           });
         } else {

--- a/test/http_proxy_test.dart
+++ b/test/http_proxy_test.dart
@@ -228,8 +228,8 @@ class ProxyServer {
           Socket.connect(tmp[0], int.parse(tmp[1])).then((socket) {
             request.response.reasonPhrase = "Connection established";
             request.response.detachSocket().then((detached) {
-              socket.pipe(detached);
-              detached.pipe(socket);
+              socket.cast<List<int>>().pipe(detached);
+              detached.cast<List<int>>().pipe(socket);
             });
           });
         } else {


### PR DESCRIPTION
An upcoming change in the Dart SDK will change `Socket`
from implementing `Stream<List<int>>` to implementing
`Stream<Uint8List>`.
    
This breaking change in the `http_io` package corresponds
to that breaking change in the SDK. As such, this change
also bumps the minimum SDK constraint accordingly.
    
https://github.com/dart-lang/sdk/issues/36900