### PR TITLE
Prepare for Socket breaking change

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/dart-lang/http_io
 description: HTTP Client and Server APIs.
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.2.0 <2.5.0"
 
 dev_dependencies:
   convert: ^2.0.1


### PR DESCRIPTION
Set an upper bound on the SDK constraint to
prepare for the SDK breaking change of Socket
implementing `Stream<Uint8List>`.

https://github.com/dart-lang/sdk/issues/36900